### PR TITLE
Adjustments to work with Xcode 16 or newer

### DIFF
--- a/ProfileManager/ProfileManager.xcodeproj/project.pbxproj
+++ b/ProfileManager/ProfileManager.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -110,7 +110,8 @@
 		EC045ACC1BBC86B1008B8259 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1010;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = Hipo;
 				TargetAttributes = {
 					EC045AD31BBC86B1008B8259 = {
@@ -121,7 +122,7 @@
 			};
 			buildConfigurationList = EC045ACF1BBC86B1008B8259 /* Build configuration list for PBXProject "ProfileManager" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -180,6 +181,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -198,6 +200,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -205,9 +208,12 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = GSS77QYM85;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -233,6 +239,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -251,6 +258,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -258,9 +266,12 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = GSS77QYM85;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -281,9 +292,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = GSS77QYM85;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = ProfileManager/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hipo.ProfileManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -295,9 +311,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = GSS77QYM85;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = ProfileManager/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hipo.ProfileManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/ProfileManager/ProfileManager/PMWindowController.m
+++ b/ProfileManager/ProfileManager/PMWindowController.m
@@ -105,7 +105,13 @@ static NSString * const PMProfileCellIdentifier = @"PMProfileCell";
 - (void)loadProfiles {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSURL *libraryDirectoryURL = [self getLibraryDirectoryURL];
-    NSURL *profilesDirectoryURL = [libraryDirectoryURL URLByAppendingPathComponent:@"MobileDevice/Provisioning Profiles"];
+    NSArray<NSNumber*>* xcodeVersion = [self parseVersionComponents: [self getXcodeVersion]];
+    NSURL *profilesDirectoryURL;
+    if (xcodeVersion[0].intValue < 16) {
+        profilesDirectoryURL = [libraryDirectoryURL URLByAppendingPathComponent:@"MobileDevice/Provisioning Profiles"];
+    } else {
+        profilesDirectoryURL = [libraryDirectoryURL URLByAppendingPathComponent:@"Developer/Xcode/UserData/Provisioning Profiles"];
+    }
     
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:profilesDirectoryURL
                                           includingPropertiesForKeys:@[NSURLNameKey]
@@ -230,6 +236,53 @@ static NSString * const PMProfileCellIdentifier = @"PMProfileCell";
 
 - (void)didTapReloadButton:(id)sender {
     [self reloadAllProfiles];
+}
+
+// MARK: - Xcode Version
+
+- (NSString*) getXcodeVersion {
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = @"/usr/bin/xcodebuild";
+    task.arguments = @[@"-version"];
+
+    NSPipe *pipe = [NSPipe pipe];
+    task.standardOutput = pipe;
+
+    NSFileHandle *file = [pipe fileHandleForReading];
+
+    @try {
+        [task launch];
+    } @catch (NSException *exception) {
+        NSLog(@"Fehler beim Ausführen von xcodebuild: %@", exception);
+        return nil;
+    }
+
+    NSData *data = [file readDataToEndOfFile];
+    NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+    NSArray<NSString *> *lines = [output componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    for (NSString *line in lines) {
+        if ([line hasPrefix:@"Xcode "]) {
+            return [line stringByReplacingOccurrencesOfString:@"Xcode " withString:@""];
+        }
+    }
+
+    return nil;
+}
+
+- (NSArray<NSNumber *>*) parseVersionComponents: (NSString *) versionString {
+    if (versionString.length == 0) return @[];
+
+    NSMutableArray<NSNumber *> *numbers = [NSMutableArray array];
+    NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+
+    for (NSString *part in [versionString componentsSeparatedByString:@"."]) {
+        NSString *digitsOnly = [[part componentsSeparatedByCharactersInSet:nonDigits] componentsJoinedByString:@""];
+        if (digitsOnly.length > 0) {
+            [numbers addObject:@(digitsOnly.integerValue)];
+        }
+    }
+    return numbers;
 }
 
 @end


### PR DESCRIPTION
Xcode 16  saves provisioning profiles at a different location on disk. I created a switch to work with older versions and newer versions of Xcode